### PR TITLE
PubSub Fix

### DIFF
--- a/p2p/test/reconnects/reconnect_test.go
+++ b/p2p/test/reconnects/reconnect_test.go
@@ -54,7 +54,9 @@ func newSender() (chan sendChans, func(s network.Stream)) {
 		scc <- sc
 
 		defer func() {
-			s.Close()
+			if s != nil {
+				s.Close()
+			}
 			sc.closed <- struct{}{}
 		}()
 

--- a/pkg/pubsub/blacklist_test.go
+++ b/pkg/pubsub/blacklist_test.go
@@ -40,6 +40,11 @@ func TestBlacklist(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 2)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 	connect(t, hosts[0], hosts[1])
 
@@ -68,6 +73,11 @@ func TestBlacklist2(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 2)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 	connect(t, hosts[0], hosts[1])
 
@@ -101,6 +111,11 @@ func TestBlacklist3(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 2)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 
 	psubs[1].BlacklistPeer(hosts[0].ID())

--- a/pkg/pubsub/discovery_test.go
+++ b/pkg/pubsub/discovery_test.go
@@ -135,6 +135,11 @@ func TestSimpleDiscovery(t *testing.T) {
 	discOpts := []discovery.Option{discovery.Limit(numHosts), discovery.TTL(1 * time.Minute)}
 
 	hosts := getNetHosts(t, ctx, numHosts)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := make([]*PubSub, numHosts)
 	topicHandlers := make([]*Topic, numHosts)
 
@@ -234,6 +239,11 @@ func TestGossipSubDiscoveryAfterBootstrap(t *testing.T) {
 
 	// Put the pubsub clients into two partitions
 	hosts := getNetHosts(t, ctx, numHosts)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := make([]*PubSub, numHosts)
 	topicHandlers := make([]*Topic, numHosts)
 

--- a/pkg/pubsub/floodsub_test.go
+++ b/pkg/pubsub/floodsub_test.go
@@ -1005,6 +1005,7 @@ func TestWithSigning(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// TODO(bonedaddy): this is hanging for some reason
 	msg, err := sub.Next(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/pubsub/floodsub_test.go
+++ b/pkg/pubsub/floodsub_test.go
@@ -46,8 +46,10 @@ func getNetHosts(t *testing.T, ctx context.Context, n int) []host.Host {
 }
 
 func connect(t *testing.T, a, b host.Host) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 	pinfo := a.Peerstore().PeerInfo(a.ID())
-	err := b.Connect(context.Background(), pinfo)
+	err := b.Connect(ctx, pinfo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +123,11 @@ func TestBasicFloodsub(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	hosts := getNetHosts(t, ctx, 20)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 
 	var msgs []*Subscription
@@ -164,7 +170,11 @@ func TestMultihops(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 6)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 
 	connect(t, hosts[0], hosts[1])
@@ -206,7 +216,11 @@ func TestReconnects(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 3)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 
 	connect(t, hosts[0], hosts[1])
@@ -280,7 +294,11 @@ func TestNoConnection(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 10)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 
 	ch, err := psubs[5].Subscribe("foobar")
@@ -305,7 +323,7 @@ func TestSelfReceive(t *testing.T) {
 	defer cancel()
 
 	host := getNetHosts(t, ctx, 1)[0]
-
+	defer host.Close()
 	psub, err := NewFloodSub(ctx, host)
 	if err != nil {
 		t.Fatal(err)
@@ -339,6 +357,11 @@ func TestOneToOne(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 2)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 
 	connect(t, hosts[0], hosts[1])
@@ -358,6 +381,11 @@ func TestRegisterUnregisterValidator(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 1)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 
 	err := psubs[0].RegisterTopicValidator("foo", func(context.Context, peer.ID, *Message) bool {
@@ -383,6 +411,11 @@ func TestValidate(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 2)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 
 	connect(t, hosts[0], hosts[1])
@@ -565,6 +598,11 @@ func TestTreeTopology(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 10)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 
 	connect(t, hosts[0], hosts[1])
@@ -628,7 +666,11 @@ func TestFloodSubPluggableProtocol(t *testing.T) {
 		defer cancel()
 
 		hosts := getNetHosts(t, ctx, 3)
-
+		defer func() {
+			for _, host := range hosts {
+				host.Close()
+			}
+		}()
 		psubA := mustCreatePubSub(ctx, t, hosts[0], "/esh/floodsub", "/lsr/floodsub")
 		psubB := mustCreatePubSub(ctx, t, hosts[1], "/esh/floodsub")
 		psubC := mustCreatePubSub(ctx, t, hosts[2], "/lsr/floodsub")
@@ -660,7 +702,11 @@ func TestFloodSubPluggableProtocol(t *testing.T) {
 		defer cancel()
 
 		hosts := getNetHosts(t, ctx, 2)
-
+		defer func() {
+			for _, host := range hosts {
+				host.Close()
+			}
+		}()
 		psubA := mustCreatePubSub(ctx, t, hosts[0], "/esh/floodsub")
 		psubB := mustCreatePubSub(ctx, t, hosts[1], "/lsr/floodsub")
 
@@ -715,6 +761,7 @@ func TestSubReporting(t *testing.T) {
 	defer cancel()
 
 	host := getNetHosts(t, ctx, 1)[0]
+	defer host.Close()
 	psub, err := NewFloodSub(ctx, host)
 	if err != nil {
 		t.Fatal(err)
@@ -758,6 +805,11 @@ func TestPeerTopicReporting(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 4)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 
 	connect(t, hosts[0], hosts[1])
@@ -815,6 +867,11 @@ func TestSubscribeMultipleTimes(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 2)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 
 	connect(t, hosts[0], hosts[1])
@@ -861,6 +918,11 @@ func TestPeerDisconnect(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 2)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 
 	connect(t, hosts[0], hosts[1])
@@ -919,6 +981,11 @@ func TestWithSigning(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 2)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts, WithStrictSignatureVerification(true))
 
 	connect(t, hosts[0], hosts[1])
@@ -955,6 +1022,11 @@ func TestImproperlySignedMessageRejected(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 2)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	adversary := hosts[0]
 	honestPeer := hosts[1]
 
@@ -1073,6 +1145,11 @@ func TestMessageSender(t *testing.T) {
 	const topic = "foobar"
 
 	hosts := getNetHosts(t, ctx, 3)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 
 	var msgs []*Subscription

--- a/pkg/pubsub/gossipsub_test.go
+++ b/pkg/pubsub/gossipsub_test.go
@@ -31,7 +31,11 @@ func TestSparseGossipsub(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	hosts := getNetHosts(t, ctx, 20)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 
 	var msgs []*Subscription
@@ -72,7 +76,11 @@ func TestDenseGossipsub(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	hosts := getNetHosts(t, ctx, 20)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 
 	var msgs []*Subscription
@@ -113,7 +121,11 @@ func TestGossipsubFanout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	hosts := getNetHosts(t, ctx, 20)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 
 	var msgs []*Subscription
@@ -182,7 +194,11 @@ func TestGossipsubFanoutMaintenance(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	hosts := getNetHosts(t, ctx, 20)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 
 	var msgs []*Subscription
@@ -265,7 +281,11 @@ func TestGossipsubFanoutExpiry(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	hosts := getNetHosts(t, ctx, 10)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 
 	var msgs []*Subscription
@@ -324,7 +344,11 @@ func TestGossipsubGossip(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	hosts := getNetHosts(t, ctx, 20)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 
 	var msgs []*Subscription
@@ -371,7 +395,11 @@ func TestGossipsubGossipPiggyback(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	hosts := getNetHosts(t, ctx, 20)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 
 	var msgs []*Subscription
@@ -440,6 +468,11 @@ func TestGossipsubGossipPropagation(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 20)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 
 	hosts1 := hosts[:GossipSubD+1]
@@ -520,7 +553,11 @@ func TestGossipsubPrune(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	hosts := getNetHosts(t, ctx, 20)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 
 	var msgs []*Subscription
@@ -569,7 +606,11 @@ func TestGossipsubGraft(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	hosts := getNetHosts(t, ctx, 20)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 
 	sparseConnect(t, hosts)
@@ -614,7 +655,11 @@ func TestGossipsubRemovePeer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	hosts := getNetHosts(t, ctx, 20)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 
 	var msgs []*Subscription
@@ -664,6 +709,11 @@ func TestGossipsubGraftPruneRetry(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 10)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 	denseConnect(t, hosts)
 
@@ -714,6 +764,11 @@ func TestGossipsubControlPiggyback(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 10)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 	denseConnect(t, hosts)
 
@@ -795,7 +850,11 @@ func TestMixedGossipsub(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	hosts := getNetHosts(t, ctx, 30)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	gsubs := getGossipsubs(ctx, hosts[:20])
 	fsubs := getPubsubs(ctx, hosts[20:])
 	psubs := append(gsubs, fsubs...)
@@ -839,7 +898,11 @@ func TestGossipsubMultihops(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 6)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 
 	connect(t, hosts[0], hosts[1])
@@ -882,6 +945,11 @@ func TestGossipsubTreeTopology(t *testing.T) {
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 10)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getGossipsubs(ctx, hosts)
 
 	connect(t, hosts[0], hosts[1])

--- a/pkg/pubsub/topic_test.go
+++ b/pkg/pubsub/topic_test.go
@@ -78,6 +78,11 @@ func testTopicCloseWithOpenResource(t *testing.T, openResource func(topic *Topic
 	const numHosts = 1
 	topicID := "foobar"
 	hosts := getNetHosts(t, ctx, numHosts)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	ps := getPubsub(ctx, hosts[0])
 
 	// Try create and cancel topic
@@ -118,7 +123,11 @@ func TestTopicReuse(t *testing.T) {
 	const numHosts = 2
 	topicID := "foobar"
 	hosts := getNetHosts(t, ctx, numHosts)
-
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	sender := getPubsub(ctx, hosts[0], WithDiscovery(&dummyDiscovery{}))
 	receiver := getPubsub(ctx, hosts[1])
 
@@ -215,6 +224,11 @@ func TestTopicEventHandlerCancel(t *testing.T) {
 	const numHosts = 5
 	topicID := "foobar"
 	hosts := getNetHosts(t, ctx, numHosts)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	ps := getPubsub(ctx, hosts[0])
 
 	// Try create and cancel topic
@@ -247,6 +261,11 @@ func TestSubscriptionJoinNotification(t *testing.T) {
 	const numLateSubscribers = 10
 	const numHosts = 20
 	hosts := getNetHosts(t, ctx, numHosts)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	topics := getTopics(getPubsubs(ctx, hosts), "foobar")
 	evts := getTopicEvts(topics)
 
@@ -313,6 +332,11 @@ func TestSubscriptionLeaveNotification(t *testing.T) {
 
 	const numHosts = 20
 	hosts := getNetHosts(t, ctx, numHosts)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	psubs := getPubsubs(ctx, hosts)
 	topics := getTopics(psubs, "foobar")
 	evts := getTopicEvts(topics)

--- a/pkg/pubsub/topic_test.go
+++ b/pkg/pubsub/topic_test.go
@@ -420,6 +420,11 @@ func TestSubscriptionManyNotifications(t *testing.T) {
 
 	const numHosts = 33
 	hosts := getNetHosts(t, ctx, numHosts)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	topics := getTopics(getPubsubs(ctx, hosts), topic)
 	evts := getTopicEvts(topics)
 
@@ -525,6 +530,11 @@ func TestSubscriptionNotificationSubUnSub(t *testing.T) {
 
 	const numHosts = 35
 	hosts := getNetHosts(t, ctx, numHosts)
+	defer func() {
+		for _, host := range hosts {
+			host.Close()
+		}
+	}()
 	topics := getTopics(getPubsubs(ctx, hosts), topic)
 
 	for i := 1; i < numHosts; i++ {

--- a/pkg/pubsub/validation.go
+++ b/pkg/pubsub/validation.go
@@ -271,6 +271,8 @@ loop:
 		rcount++
 
 		select {
+		case <-ctx.Done():
+			return false
 		case val.validateThrottle <- struct{}{}:
 			go func(val *topicVal) {
 				rch <- val.validateMsg(ctx, src, msg)


### PR DESCRIPTION
This should act as a temporary band-aid fix to get tests from failing repeatedly due to timeouts, however  we can do with a refactor of the pubsub system